### PR TITLE
Fix HTTPCORE-549 in parent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -963,7 +963,25 @@ Fixed JIRA link
         </plugins>
       </build>
     </profile>
-    
+    <profile>
+      <id>owasp</id>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>3.3.1</version>
+            <reportSets>
+              <reportSet>
+                <reports>
+                  <report>aggregate</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
   </profiles>
 
   <prerequisites>


### PR DESCRIPTION
See https://github.com/apache/httpcomponents-core/pull/73,  in parent project we can do owasp-dependency-check in all httpcomponents child projects